### PR TITLE
Update rsrc_pool.app.src

### DIFF
--- a/src/rsrc_pool.app.src
+++ b/src/rsrc_pool.app.src
@@ -10,7 +10,6 @@
     },
     {registered, []},
     {applications, [kernel, stdlib]},
-    {mod, {resource_pool_srv, []}},
     {env, []}
 	]
 }.


### PR DESCRIPTION
Retirado referencia ap modulo principal para corrigir problema de compilação em projetos que usem o rebar3